### PR TITLE
Use pipeline_name variable for jobName

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -204,7 +204,7 @@ profiles {
             perJobMemLimit = true
             submitRateLimit = params.submit_rate_limit
             queueSize = params.queue_size
-            // pipeline_name is a variable to be overriden pipeline-specific config
+            // pipeline_name is a variable to be set in pipeline-specific config
             jobName = { "$pipeline_name - $task.name - $task.hash" }
         }
 

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -204,7 +204,8 @@ profiles {
             perJobMemLimit = true
             submitRateLimit = params.submit_rate_limit
             queueSize = params.queue_size
-            jobName = { "$manifest.name - $task.name - $task.hash" }
+            // pipeline_name is a variable to be overriden pipeline-specific config
+            jobName = { "$pipeline_name - $task.name - $task.hash" }
         }
 
         params {


### PR DESCRIPTION
`manifest.name` is not accessible within the `executor.jobName` closure. We get around this by defining a variable in each pipeline-specific `nextflow.config`, which can be used for defining `manifest.name` too.