### PR TITLE
Update process selector labels

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -129,33 +129,33 @@ process {
     errorStrategy = { retry_strategy(task, params.max_retries) }
 
     // Process-specific resource requirements
-    withLabel:process_low {
-        cpus   = { check_max( 2, 'cpus') }
+    withLabel:cpu_2_mem_1_time_1 {
+        cpus   = { check_max( 2, 'cpus' ) }
         memory = { check_max( escalate_exp( 1.GB, task, 2 ), 'memory' ) }
         time   = { check_max( escalate_exp( 1.h, task, 2 ), 'time' ) }
     }
 
-    withLabel:process_medium {
-        cpus   = { check_max( 4, 'cpus') }
+    withLabel:cpu_4_mem_8_time_12 {
+        cpus   = { check_max( 4, 'cpus' ) }
         memory = { check_max( escalate_exp( 8.GB, task, 2 ), 'memory' ) }
         time   = { check_max( escalate_exp( 12.h, task, 2 ), 'time' ) }
     }
 
-    withLabel:process_high {
-        cpus   = { check_max( 8, 'cpus') }
+    withLabel:cpu_8_mem_16_time_12 {
+        cpus   = { check_max( 8, 'cpus' ) }
         memory = { check_max( escalate_exp( 16.GB, task, 2 ), 'memory' ) }
         time   = { check_max( escalate_exp( 12.h, task, 2 ), 'time' ) }
     }
 
-    withLabel:process_long {
+    withLabel:long {
         time   = { check_max( escalate_linear( 48.h, task ), 'time' ) }
     }
 
-    withLabel:process_high_memory {
+    withLabel:mem_32 {
         memory = { check_max( escalate_exp( 32.GB, task, 2 ), 'memory' ) }
     }
 
-    withLabel:error_ignore {
+    withLabel:no_retry {
         errorStrategy = 'ignore'
     }
 }


### PR DESCRIPTION
Currently, you can't set custom resource requirements in the actual pipeline config as the functions required to use those settings do not exist outside of the common config.

With the current labels (low, medium, high, ignore) there isn't much room for expantion on this and is already quite cryptic as for example medium is different between pipelines

We propose adding a new labeling system where it describes the resources i.e.
```
cpu_X_mem_X_time_X
```
i.e for 4 cps 8gb memory for 12 hours
```
cpu_4_mem_8_time_12
```
This allows us to have descriptive labels which we can add to the pipelines and allow us to add rather than deleting and editing labels as new pipelines come out.