### PR TITLE
Change pipeline_jobname strategy

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -205,7 +205,7 @@ profiles {
             perJobMemLimit = true
             submitRateLimit = params.submit_rate_limit
             queueSize = params.queue_size
-            // pipeline_name is a variable to be set in pipeline-specific config
+            // Each pipeline should override params.pipeline_jobname in pipeline-specific config
             jobName = { "$params.pipeline_jobname - $task.name - $task.hash" }
         }
 

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -9,7 +9,7 @@
 // Manifest providing default pipeline description
 // Every pipeline should override this
 manifest {
-    name            = 'pipeline'
+    name            = 'PAM pipeline'
     author          = 'PAM Informatics'
     homePage        = 'NA'
     description     = 'NA'
@@ -37,6 +37,7 @@ params {
     // LSF
     queue_size = null
     submit_rate_limit = null
+    pipeline_jobname = "${manifest.name}"
 }
 
 // Specify process resource requirements and escalation strategy
@@ -205,7 +206,7 @@ profiles {
             submitRateLimit = params.submit_rate_limit
             queueSize = params.queue_size
             // pipeline_name is a variable to be set in pipeline-specific config
-            jobName = { "$pipeline_name - $task.name - $task.hash" }
+            jobName = { "$params.pipeline_jobname - $task.name - $task.hash" }
         }
 
         params {


### PR DESCRIPTION
Allow users to customise the pipeline jobname (LSF jobname), with a sensible default (in the shared nextflow.config). Each pipeline can/should set it's own `params.pipeline_jobname` to define a default name.