### PR TITLE
Add time escalation matching queues and change labeling (again)

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -98,7 +98,7 @@ def escalate_queue_time(queue, task) {
     if (index < 4) {
         return "${times[index]}.h"
     }
-    return "${times[3]}"
+    return "${times[3]}.h"
 }
 
 def retry_strategy(task, max_retries) {

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -144,30 +144,48 @@ process {
     errorStrategy = { retry_strategy(task, params.max_retries) }
 
     // Process-specific resource requirements
-    withLabel:cpu_2_mem_1_time_1 {
+    withLabel:cpu_1 {
+        cpus   = { check_max( 1, 'cpus' ) }
+    }
+
+    withLabel:cpu_2 {
         cpus   = { check_max( 2, 'cpus' ) }
-        memory = { check_max( escalate_exp( 1.GB, task, 2 ), 'memory' ) }
-        time   = { check_max( escalate_exp( 1.h, task, 2 ), 'time' ) }
     }
 
-    withLabel:cpu_4_mem_8_time_12 {
+    withLabel:cpu_4 {
         cpus   = { check_max( 4, 'cpus' ) }
-        memory = { check_max( escalate_exp( 8.GB, task, 2 ), 'memory' ) }
-        time   = { check_max( escalate_exp( 12.h, task, 2 ), 'time' ) }
     }
 
-    withLabel:cpu_8_mem_16_time_12 {
+    withLabel:cpu_8 {
         cpus   = { check_max( 8, 'cpus' ) }
-        memory = { check_max( escalate_exp( 16.GB, task, 2 ), 'memory' ) }
-        time   = { check_max( escalate_exp( 12.h, task, 2 ), 'time' ) }
     }
 
-    withLabel:long {
-        time   = { check_max( escalate_linear( 48.h, task ), 'time' ) }
+    withLabel:mem_1 {
+        memory = { check_max( escalate_exp( 1.GB, task, 2 ), 'memory' ) }
+    }
+    
+    withLabel:mem_8 {
+        memory = { check_max( escalate_exp( 8.GB, task, 2 ), 'memory' ) }
+    }
+    
+    withLabel:mem_16 {
+        memory = { check_max( escalate_exp( 16.GB, task, 2 ), 'memory' ) }
     }
 
     withLabel:mem_32 {
         memory = { check_max( escalate_exp( 32.GB, task, 2 ), 'memory' ) }
+    }
+    
+    withLabel:time_1 {
+        time   = { check_max( escalate_linear( 1.h, task ), 'time' ) }
+    }
+
+    withLabel:time_12 {
+        time   = { check_max( escalate_exp( 12.h, task, 2 ), 'time' ) }
+    }
+
+    withLabel:time_48 {
+        time   = { check_max( escalate_linear( 48.h, task, 2 ), 'time' ) }
     }
 
     withLabel:no_retry {

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -87,14 +87,14 @@ def escalate_exp(initial, task, multiplier=1) {
 }
 
 def escalate_queue_time(queue, task) {
-    queue_index = [
+    def queue_index = [
         "normal": 0,
         "long": 1,
         "week": 2,
         "basement": 3,
     ]
-    times = [12, 48, 168, 720]
-    index = queue_index[queue] + (task.attempt - 1)
+    def times = [12, 48, 168, 720]
+    def index = queue_index[queue] + (task.attempt - 1)
     if (index < 4) {
         return "${times[index]}.h"
     }

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -163,6 +163,14 @@ process {
     withLabel:mem_1 {
         memory = { check_max( escalate_exp( 1.GB, task, 2 ), 'memory' ) }
     }
+
+    withLabel:mem_2 {
+        memory = { check_max( escalate_exp( 2.GB, task, 2 ), 'memory' ) }
+    }
+
+    withLabel:mem_4 {
+        memory = { check_max( escalate_exp( 4.GB, task, 2 ), 'memory' ) }
+    }
     
     withLabel:mem_8 {
         memory = { check_max( escalate_exp( 8.GB, task, 2 ), 'memory' ) }

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -86,6 +86,21 @@ def escalate_exp(initial, task, multiplier=1) {
     return (initial * (multiplier ** (task.attempt - 1)))
 }
 
+def escalate_queue_time(queue, task) {
+    queue_index = [
+        "normal": 0,
+        "long": 1,
+        "week": 2,
+        "basement": 3,
+    ]
+    times = [12, 48, 168, 720]
+    index = queue_index[queue] + (task.attempt - 1)
+    if (index < 4) {
+        return "${times[index]}.h"
+    }
+    return "${times[3]}"
+}
+
 def retry_strategy(task, max_retries) {
     def MISC_EXIT_CODES = [
         "SIGKILL": 137,
@@ -158,6 +173,10 @@ process {
     withLabel:no_retry {
         errorStrategy = 'ignore'
     }
+
+    withLabel:time_match_queue {
+        time = { check_max( escalate_queue_time( 'normal', task ), 'time' ) }
+    }
 }
 
 
@@ -196,6 +215,7 @@ profiles {
                       task.memory > 196.GB ? 'hugemem' :
                       task.time <= 12.h ? 'normal' :
                       task.time <= 48.h ? 'long' :
+                      task.time <= 168.h ? 'week' :
                       'basement' }
         }
 

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -175,7 +175,11 @@ process {
     withLabel:mem_8 {
         memory = { check_max( escalate_exp( 8.GB, task, 2 ), 'memory' ) }
     }
-    
+
+    withLabel:mem_10 {
+        memory = { check_max( escalate_exp( 10.GB, task, 2 ), 'memory' ) }
+    }
+
     withLabel:mem_16 {
         memory = { check_max( escalate_exp( 16.GB, task, 2 ), 'memory' ) }
     }

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -200,7 +200,7 @@ process {
         errorStrategy = 'ignore'
     }
 
-    withLabel:time_match_queue {
+    withLabel:time_queue_from_normal {
         time = { check_max( escalate_queue_time( 'normal', task ), 'time' ) }
     }
 }


### PR DESCRIPTION
Time escalation matching to queues is useful when you don't want to impose strict time limits on processes finishing and want to rely on the inherent farm limits instead.

Propose to change labels to higher resolution, so we can easily mix and match without needing to add new labels as often.