### PR TITLE
Use param for retry strategy

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -103,6 +103,13 @@ def escalate_queue_time(queue, task) {
 }
 
 def retry_strategy(task, max_retries) {
+    def MISC_EXIT_CODES = [
+        "SIGKILL": 137,
+        "SIGTERM": 143,
+        "SIGABRT": 134,
+        "SIGSEGV": 139
+    ].values()
+
     def SCALING_EXIT_CODES = [
         "SIGINT": 130,  // LSF Out of memory Error or bkill
         "SIGUSR2": 140, // LSF Runlimit exceeded Error
@@ -113,6 +120,10 @@ def retry_strategy(task, max_retries) {
     }
 
     switch(task.exitStatus) {
+        case {it in MISC_EXIT_CODES}:
+            // Ignore due to non-scalable error code
+            return 'ignore'
+
         case {it in SCALING_EXIT_CODES}:
             // Retry with more memory and longer time limit
             return 'retry'

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -33,6 +33,7 @@ params {
     max_cpus = 2
     max_time = '10000.h'
     max_retries = 2
+    retry_strategy = 'ignore'
 
     // LSF
     queue_size = null
@@ -102,13 +103,6 @@ def escalate_queue_time(queue, task) {
 }
 
 def retry_strategy(task, max_retries) {
-    def MISC_EXIT_CODES = [
-        "SIGKILL": 137,
-        "SIGTERM": 143,
-        "SIGABRT": 134,
-        "SIGSEGV": 139
-    ].values()
-
     def SCALING_EXIT_CODES = [
         "SIGINT": 130,  // LSF Out of memory Error or bkill
         "SIGUSR2": 140, // LSF Runlimit exceeded Error
@@ -119,17 +113,12 @@ def retry_strategy(task, max_retries) {
     }
 
     switch(task.exitStatus) {
-        case {it in MISC_EXIT_CODES}:
-            // Ignore due to non-scalable error code
-            return 'ignore'
-
         case {it in SCALING_EXIT_CODES}:
             // Retry with more memory and longer time limit
             return 'retry'
 
         default:
-            // Ignore any other error codes
-            return 'ignore'
+            return params.retry_strategy
     }
 }
 


### PR DESCRIPTION
Allow users to override pipeline retry strategy, if desired. Should be tested before merging.

As mentioned on https://github.com/sanger-pathogens/nextflow-commons/pull/9