### PR TITLE
add mem64 label

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -187,6 +187,10 @@ process {
     withLabel:mem_32 {
         memory = { check_max( escalate_exp( 32.GB, task, 2 ), 'memory' ) }
     }
+
+    withLabel:mem_64 {
+        memory = { check_max( escalate_exp( 64.GB, task, 2 ), 'memory' ) }
+    }
     
     withLabel:time_1 {
         time   = { check_max( escalate_linear( 1.h, task ), 'time' ) }


### PR DESCRIPTION
missing mem64 label used in MAGs pipeline, my guess is the pipeline is defaulting to 1GB as it doesn't recognise the mem_64 label which is causing the errors.

E.g. in the bin refinement process here from Mat B's ticket (https://rt.sanger.ac.uk/Ticket/Display.html?id=786139)

```
(base) ol6@farm5-head1:/lustre/scratch125/pam/teams/team216/mb29/STI_Metagenomics/MAGUS_GUD_data/MAGUS_shotgun_data/Zim_batch1__08-2023/analysis/metawrap/work/d5/c27e62541e2d8b51443b766a5ed4ab$ tail -20 /lustre/scratch125/pam/teams/team216/mb29/STI_Metagenomics/MAGUS_GUD_data/MAGUS_shotgun_data/Zim_batch1__08-2023/analysis/metawrap/work/d5/c27e62541e2d8b51443b766a5ed4ab/.command.log
------------------------------------------------------------

TERM_MEMLIMIT: job killed after reaching LSF memory usage limit.
Exited with exit code 130.

Resource usage summary:

    CPU time :                                   1388.00 sec.
    Max Memory :                                 4054 MB
    Average Memory :                             456.82 MB
    Total Requested Memory :                     3072.00 MB
    Delta Memory :                               -982.00 MB
    Max Swap :                                   -
    Max Processes :                              44
    Max Threads :                                69
    Run time :                                   458 sec.
    Turnaround time :                            611 sec.

The output (if any) is above this job summary.
```

Doing a bit more digging:
```
(base) ol6@farm5-head1:/lustre/scratch125/pam/teams/team216/mb29/STI_Metagenomics/MAGUS_GUD_data/MAGUS_shotgun_data/Zim_batch1__08-2023/analysis/metawrap/work$ for f in `grep -l "bin_refinement" */*/.command.log`; do grep "Total Requested Memory" $f; done | sort -u
    Total Requested Memory :                     102400.00 MB
    Total Requested Memory :                     1024.00 MB
    Total Requested Memory :                     2048.00 MB
    Total Requested Memory :                     3072.00 MB
```
A couple of samples requested 100GB memory for some reason, but 99% of them were 1-3GB memory, so I'm pretty confident this is the issue here. running out of memory also explains the core dumping