### PR TITLE
Add small queue to escalate_queue_time

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -88,17 +88,18 @@ def escalate_exp(initial, task, multiplier=1) {
 
 def escalate_queue_time(queue, task) {
     def queue_index = [
-        "normal": 0,
-        "long": 1,
-        "week": 2,
-        "basement": 3,
+        "small": 0
+        "normal": 1,
+        "long": 2,
+        "week": 3,
+        "basement": 4,
     ]
-    def times = [12, 48, 168, 720]
+    def times = ["30.m", "12.h", "48.h", "7.d", "30.d"]
     def index = queue_index[queue] + (task.attempt - 1)
     if (index < 4) {
-        return "${times[index]}.h"
+        return times[index]
     }
-    return "${times[3]}.h"
+    return times[4]
 }
 
 def retry_strategy(task, max_retries) {


### PR DESCRIPTION
Changes allow user to escalate from `small` queue. Also changed the way the function constructs the time values.