### PR TITLE
Use env variable for libraryDir

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -283,7 +283,7 @@ profiles {
             autoMounts = true
             runOptions = '--bind /data,/lustre,/nfs,/software'
             // To avoid downloading/converting to singularity image every time
-            libraryDir = '/software/pathogen/custom_installs/singularity_cache'
+            libraryDir = System.getenv("NEXTFLOW_SINGULARITY_LIBRARY")
         }
 
         process {


### PR DESCRIPTION
Using an environment variable here offers more flexibility for users wanting to modify the libraryDir to something appropriate for them.