### PR TITLE
Removing docker.userEmulation from config

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -266,7 +266,6 @@ profiles {
 
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
         singularity.enabled    = false
         conda.enabled         = false
     }


### PR DESCRIPTION
It looks like `docker.userEmulation` is no longer supported from nextflow 24.01.0.

There was some discussion on what to do about this here:  
https://nextflow.slack.com/archives/C02T98A23U7/p1709049357728229

It looks like our options are to either remove it or to add settings similar to what `docker.userEmulation` achieved via `docker.runOptions` or `process.containerOptions` (less desirable).

According to https://nextflow.slack.com/archives/C02T98A23U7/p1696591307155289?thread_ts=1696590982.727319&cid=C02T98A23U7, it apparently used to add the following arguments to the docker invocation:
```
-u $(id -u) -e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro -v $HOME:$HOME
```

I'm suggesting that we just remove it in the hope that it was never truly required by any of our pipelines. That said, according to the discussions above, it could be that `GATK` requires:
```
docker.runOptions = '-u $(id -u):$(id -g)'
```

So we might need to test with a pipeline that users GATK if we want to be more confident that it's not required for that. 