### PR TITLE
Integer.MAX_VALUE

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -120,7 +120,7 @@ def retry_strategy(task, max_retries) {
                          // Apparently kills the job instantly so that the exit status has not got time to be written into an .exitcode file and is not reported to the Nextflow 
                          // master process - therefore the value 9 is never seen here in practice; see below for actual value.
                          // source of issue reported here https://github.com/nextflow-io/nextflow/issues/2847 
-        "NOEXITCODE": Integer.MAX_VALUE // the default value of $task.exitStatus; this is what it is set to when not set in the absence of an .exitcode file for the previous execution of the task, as would happen in the case mentioned above
+        "NOEXITCODE": Integer.MAX_VALUE // the default value of $task.exitStatus; this is what it is set to in the absence of an .exitcode file for the previous execution of the task, as would happen in the case mentioned above
     ].values()
 
     if (task.attempt > max_retries) {

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -120,7 +120,7 @@ def retry_strategy(task, max_retries) {
                          // Apparently kills the job instantly so that the exit status has not got time to be written into an .exitcode file and is not reported to the Nextflow 
                          // master process - therefore the value 9 is never seen here in practice; see below for actual value.
                          // source of issue reported here https://github.com/nextflow-io/nextflow/issues/2847 
-        "NOEXITCODE": 2147483647 // supposedly the default value of $task.exitStatus; this is what it is set to when not set in the absence of an .exitcode file for the previous execution of the task, as would happen in the case mentioned above
+        "NOEXITCODE": Integer.MAX_VALUE // the default value of $task.exitStatus; this is what it is set to when not set in the absence of an .exitcode file for the previous execution of the task, as would happen in the case mentioned above
     ].values()
 
     if (task.attempt > max_retries) {


### PR DESCRIPTION
according to Seqera support, the default returned value is set as Integer.MAX_VALUE; see https://github.com/nextflow-io/nextflow/issues/2847.

might be more robust to call it like this for instance to avoid it breaking if Integers are switched to 64-bit types in the future .