### PR TITLE
Fix max time error

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -53,8 +53,9 @@ def check_max(obj, type) {
                 return params.max_memory as nextflow.util.MemoryUnit
             else
                 return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+        } catch (Exception e) {
+            println "ERROR - Could not compare ${obj} to params.max_memory ${params.max_memory}! Printing exception and using process.memory = ${obj}:"
+            println "${e.toString()}"
             return obj
         }
     } else if (type == 'time') {
@@ -63,15 +64,17 @@ def check_max(obj, type) {
                 return params.max_time as nextflow.util.Duration
             else
                 return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+        } catch (Exception e) {
+            println "ERROR - Could not compare ${obj} to params.max_time ${params.max_time}! Printing exception and using process.time = ${obj}:"
+            println "${e.toString()}"
             return obj
         }
     } else if (type == 'cpus') {
         try {
             return Math.min( obj, params.max_cpus as int )
-        } catch (all) {
-            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+        } catch (Exception e) {
+            println "ERROR - Could not compare ${obj} to params.max_cpus ${params.max_cpus}! Printing exception and using process.cpus = ${obj}:"
+            println "${e.toString()}" 
             return obj
         }
     }

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -98,7 +98,7 @@ def escalate_queue_time(queue, task) {
         "week": 3,
         "basement": 4,
     ]
-    def times = ["30.m", "12.h", "48.h", "7.d", "30.d"]
+    def times = [30.m, 12.h, 48.h, 7.d, 30.d]
     def index = queue_index[queue] + (task.attempt - 1)
     if (index < 4) {
         return times[index]


### PR DESCRIPTION
Before we were getting an error message with no real descriptive/troubleshouting value:
```
   ### ERROR ###   Max time '30d' is not valid! Using default value: 12.h
```

With these changes we get a more informative message:
```
ERROR - Could not compare 12.h to params.max_time 30d! Printing exception and using process.time = 12.h:
java.lang.ClassCastException: class nextflow.util.Duration cannot be cast to class java.lang.String (nextflow.util.Duration is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')
```

And we get rid of the error by returning nextflow.util.Duration objects rather than strings from the `escalate_queue_time` function