### PR TITLE
Update nextflow.config to allow for overwrite of maxRetries

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -158,7 +158,7 @@ process {
 
     maxErrors = -1
     maxRetries = params.max_retries
-    errorStrategy = { retry_strategy(task, params.max_retries) }
+    errorStrategy = { retry_strategy(task, maxRetries) }
 
     // Process-specific resource requirements
     withLabel:cpu_1 {


### PR DESCRIPTION
Currently the param.max_retries is set as per the global at the top.

Some pipelines use a per - name method for these i.e.

withName:BOWTIE2SAMTOOLS {
        cpus = params.bowtie2_samtools_threads
        memory = {10.GB + (10.GB * task.attempt)}
        maxRetries = 3
    }

Currently this is ignored as maxRetries is overwritten but then the global parameter is used as defined above (this is not defined in the nextflow.config for the specific tool).