### PR TITLE
Slower esc from normal

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -173,6 +173,7 @@ process {
     time   = { check_max( escalate_linear( 1.h, task ), 'time' ) }
 
     maxErrors = -1
+    maxRetries = params.max_retries
     
     errorStrategy = { retry_strategy(task, params.max_retries) }
 

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -106,7 +106,7 @@ def escalate_queue_time(queue, task) {
     return times[4]
 }
 
-def escalate_queue_time2(queue, task) {
+def escalate_queue_time_by2(queue, task) {
     def queue_index = [
         "small": 0,
         "normal": 1,
@@ -280,20 +280,20 @@ process {
         time = { check_max( escalate_queue_time( 'week', task ), 'time' ) }
     }
 
-    withLabel:time_queue_from_small2 {
-        time = { check_max( escalate_queue_time2( 'small', task ), 'time' ) }
+    withLabel:time_queue_from_small_slow2 {
+        time = { check_max( escalate_queue_time_by2( 'small', task ), 'time' ) }
     }
 
-    withLabel:time_queue_from_normal2 {
-        time = { check_max( escalate_queue_time2( 'normal', task ), 'time' ) }
+    withLabel:time_queue_from_normal_slow2 {
+        time = { check_max( escalate_queue_time_by2( 'normal', task ), 'time' ) }
     }
 
-    withLabel:time_queue_from_long2 {
-        time = { check_max( escalate_queue_time2( 'long', task ), 'time' ) }
+    withLabel:time_queue_from_long_slow2 {
+        time = { check_max( escalate_queue_time_by2( 'long', task ), 'time' ) }
     }
 
-    withLabel:time_queue_from_week2 {
-        time = { check_max( escalate_queue_time2( 'week', task ), 'time' ) }
+    withLabel:time_queue_from_week_slow2 {
+        time = { check_max( escalate_queue_time_by2( 'week', task ), 'time' ) }
     }
 }
 

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -106,6 +106,22 @@ def escalate_queue_time(queue, task) {
     return times[4]
 }
 
+def escalate_queue_time2(queue, task) {
+    def queue_index = [
+        "small": 0,
+        "normal": 1,
+        "long": 2,
+        "week": 3,
+        "basement": 4,
+    ]
+    def times = [30.m, 12.h, 48.h, 7.d, 30.d]
+    def index = queue_index[queue] + Math.floor((task.attempt - 1) / 2)+ ((task.attempt - 1) % 2)
+    if (index < 4) {
+        return times[index]
+    }
+    return times[4]
+}
+
 def retry_strategy(task, max_retries) {
     def MISC_EXIT_CODES = [
         "SIGKILL": 137,
@@ -261,6 +277,22 @@ process {
 
     withLabel:time_queue_from_week {
         time = { check_max( escalate_queue_time( 'week', task ), 'time' ) }
+    }
+
+    withLabel:time_queue_from_small2 {
+        time = { check_max( escalate_queue_time2( 'small', task ), 'time' ) }
+    }
+
+    withLabel:time_queue_from_normal2 {
+        time = { check_max( escalate_queue_time2( 'normal', task ), 'time' ) }
+    }
+
+    withLabel:time_queue_from_long2 {
+        time = { check_max( escalate_queue_time2( 'long', task ), 'time' ) }
+    }
+
+    withLabel:time_queue_from_week2 {
+        time = { check_max( escalate_queue_time2( 'week', task ), 'time' ) }
     }
 }
 

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -236,7 +236,7 @@ process {
     }
 
     withLabel:time_12 {
-        time   = { check_max( escalate_exp( 12.h, task, 2 ), 'time' ) }
+        time   = { check_max( escalate_linear( 12.h, task, 2 ), 'time' ) }
     }
 
     withLabel:time_48 {

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -173,7 +173,7 @@ process {
     time   = { check_max( escalate_linear( 1.h, task ), 'time' ) }
 
     maxErrors = -1
-    maxRetries = params.max_retries
+    
     errorStrategy = { retry_strategy(task, params.max_retries) }
 
     // Process-specific resource requirements

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -115,7 +115,7 @@ def escalate_queue_time2(queue, task) {
         "basement": 4,
     ]
     def times = [30.m, 12.h, 48.h, 7.d, 30.d]
-    def index = queue_index[queue] + Math.floor((task.attempt - 1) / 2)+ ((task.attempt - 1) % 2)
+    def index = queue_index[queue] + Math.floor((task.attempt - 1) / 2)
     if (index < 4) {
         return times[index]
     }


### PR DESCRIPTION
so that on pipelines with many retries where escalation is mostly meant for memory, the job submissions don't go too quickly into large queues leading to silly pending times. example: the RVI viral metagenomics pipeline for inStrain, where memory is often a limiting factor but not runtime