### PR TITLE
Update mem_labels to inlclude option for 50M and 20G

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -206,6 +206,10 @@ process {
         cpus   = { check_max( 64, 'cpus' ) }
     }
 
+    withLabel:mem_50M {
+        memory = { check_max( escalate_exp( 50.MB, task, 2 ), 'memory' ) }
+    }    
+
     withLabel:mem_100M {
         memory = { check_max( escalate_exp( 100.MB, task, 2 ), 'memory' ) }
     }
@@ -240,6 +244,10 @@ process {
 
     withLabel:mem_16 {
         memory = { check_max( escalate_exp( 16.GB, task, 2 ), 'memory' ) }
+    }
+
+    withLabel:mem_20 {
+        memory = { check_max( escalate_exp( 20.GB, task, 2 ), 'memory' ) }
     }
 
     withLabel:mem_32 {


### PR DESCRIPTION
Updating to add new memory labels 50M and 20G for the abundance estimation pipeline.