### PR TITLE
Change min config hugemem

### DIFF
--- a/configs/minimal_WSI.config
+++ b/configs/minimal_WSI.config
@@ -22,7 +22,7 @@ profiles {
         process {
             executor = 'lsf'
             queue = { task.memory > 745.GB ? 'teramem' :
-                      task.memory > 250.GB ? 'hugemem' :
+                      task.memory > 256.GB ? 'hugemem' :
                       task.time <= 30.m ? 'small' :
                       task.time <= 12.h ? 'normal' :
                       task.time <= 48.h ? 'long' :

--- a/configs/minimal_WSI.config
+++ b/configs/minimal_WSI.config
@@ -22,7 +22,7 @@ profiles {
         process {
             executor = 'lsf'
             queue = { task.memory > 745.GB ? 'teramem' :
-                      task.memory > 196.GB ? 'hugemem' :
+                      task.memory > 250.GB ? 'hugemem' :
                       task.time <= 30.m ? 'small' :
                       task.time <= 12.h ? 'normal' :
                       task.time <= 48.h ? 'long' :

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -368,7 +368,7 @@ profiles {
         process {
             executor = 'lsf'
             queue = { task.memory > 745.GB ? 'teramem' :
-                      task.memory > 196.GB ? 'hugemem' :
+                      task.memory > 256.GB ? 'hugemem' :
                       task.time <= 30.m ? 'small' :
                       task.time <= 12.h ? 'normal' :
                       task.time <= 48.h ? 'long' :


### PR DESCRIPTION
Upon chatting to ISG, we can submit up to 256G safely on the normal queues see ticket here : https://sanger.freshservice.com/support/tickets/38412. 

Also from reading the documentation on the farm: https://ssg-confluence.internal.sanger.ac.uk/display/FARM/What+are+the+memory+limits+on+the+farm

_"By default, jobs receive a memory limit of 100MB. You can request a higher limit -- up to 256GB in the regular queues -- but if you do so you must also specify sensible resource requirements along with it"_ 