### PR TITLE
Fix escalation calculation in nextflow.config

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -86,7 +86,7 @@ def escalate_linear(initial, task, multiplier=1) {
         return initial
     }
     else{
-        return initial * multiplier * (task.attempt - 1)
+        return initial * multiplier * task.attempt
     }
 }
 


### PR DESCRIPTION
Escalate linear currently submits with the same initial value on the second attempt. This should fix that.