### PR TITLE
Update queue conditions for process executor

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -372,9 +372,7 @@ profiles {
 
         process {
             executor = 'lsf'
-            queue = { task.memory > 745.GB ? 'teramem' :
-                      task.memory > 256.GB ? 'hugemem' :
-                      task.time <= 30.m ? 'small' :
+            queue = { task.memory > 256.GB ? 'large-memory' :
                       task.time <= 12.h ? 'normal' :
                       task.time <= 48.h ? 'long' :
                       task.time <= 168.h ? 'week' :


### PR DESCRIPTION
Now that the small and hugemem clusters have been removed we should remove from the options.

Can test this commit but I think the labels for small queue can remain as they actually just set a time frame and the executor closure picks what queue is appropriate but can test