### PR TITLE
Change large-memory queue name back to hugemem

### DIFF
--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -372,7 +372,7 @@ profiles {
 
         process {
             executor = 'lsf'
-            queue = { task.memory > 256.GB ? 'large-memory' :
+            queue = { task.memory > 256.GB ? 'hugemem' :
                       task.time <= 12.h ? 'normal' :
                       task.time <= 48.h ? 'long' :
                       task.time <= 168.h ? 'week' :


### PR DESCRIPTION
ISG announced (proposed?) to reverted change of name from large-memory back to hugemem; see https://sanger-openstack.slack.com/archives/C7GFYDDMZ/p1781101098312359.